### PR TITLE
Bump JMS Serializer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=5.4",
         "webit/soap-api": "^2.1.0",
-        "jms/serializer": "^1.1.0"
+        "jms/serializer": "^2.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",


### PR DESCRIPTION
We need a higher version of JMS Serializer.
Some tests will be required. For now let's bump and tag as a new 2.2.0 version.